### PR TITLE
chore(subworkflow): suport native mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ruby-version: ["2.5", "2.6", "2.7", "3.0"]
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
         with:
-          ruby-version: 3.0.0
+          ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/dwf.gemspec
+++ b/dwf.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug', '~> 11.1.3'
   spec.add_development_dependency 'mock_redis', '~> 0.27.2'
   spec.add_dependency 'redis', '~> 4.2.0'
+  spec.add_dependency 'redis-mutex', '~> 4.0.2'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_dependency 'sidekiq', '~> 6.2.0'
   spec.add_development_dependency 'simplecov'

--- a/lib/dwf/callback.rb
+++ b/lib/dwf/callback.rb
@@ -45,6 +45,7 @@ module Dwf
       )
       batch.jobs do
         jobs.each do |job|
+          job.reload
           job.persist_and_perform_async! if job.ready_to_start?
         end
       end
@@ -67,10 +68,8 @@ module Dwf
       end.compact
     end
 
-    def with_lock(workflow_id, job_name)
-      client.check_or_lock(workflow_id, job_name)
-      yield
-      client.release_lock(workflow_id, job_name)
+    def with_lock(workflow_id, job_name, &block)
+      client.check_or_lock(workflow_id, job_name, &block)
     end
 
     def start_with_batch(node)

--- a/lib/dwf/item.rb
+++ b/lib/dwf/item.rb
@@ -50,8 +50,7 @@ module Dwf
     end
 
     def perform_async(options = {})
-      queue ||= client.config.namespace
-      Dwf::Worker.set(options.merge(queue: queue))
+      Dwf::Worker.set(options.merge(queue: queue || client.config.namespace))
         .perform_async(workflow_id, name)
     end
 

--- a/lib/dwf/workflow.rb
+++ b/lib/dwf/workflow.rb
@@ -178,10 +178,10 @@ module Dwf
       return unless sub_workflow?
 
       outgoing.each do |job_name|
-        client.check_or_lock(parent_id, job_name)
-        node = client.find_node(job_name, parent_id)
-        node.persist_and_perform_async! if node.ready_to_start?
-        client.release_lock(parent_id, job_name)
+        client.check_or_lock(parent_id, job_name) do
+          node = client.find_node(job_name, parent_id)
+          node.persist_and_perform_async! if node.ready_to_start?
+        end
       end
     end
 

--- a/spec/dwf/item_spec.rb
+++ b/spec/dwf/item_spec.rb
@@ -175,14 +175,10 @@ describe Dwf::Item, item: true do
         item.enqueue_outgoing_jobs
       end
 
-      context 'outgoing jobs ready to start' do
-        let(:started_at) { nil }
-        it { expect(a_item).to have_received(:persist_and_perform_async!) }
-      end
-
-      context 'outgoing jobs havent ready to start' do
-        let(:started_at) { Time.now.to_i }
-        it { expect(a_item).not_to have_received(:persist_and_perform_async!) }
+      it do
+        expect(client_double).to have_received(:check_or_lock) do |&block|
+          expect(block).to be_kind_of Proc
+        end
       end
     end
 

--- a/spec/dwf/workflow_spec.rb
+++ b/spec/dwf/workflow_spec.rb
@@ -360,23 +360,17 @@ describe Dwf::Workflow, workflow: true do
     let(:item) do
       Dwf::Item.new(
         workflow_id: SecureRandom.uuid,
-        id: SecureRandom.uuid,
-        started_at: started_at
+        id: SecureRandom.uuid
       )
     end
     before do
-      allow(item).to receive(:persist_and_perform_async!)
       workflow.enqueue_outgoing_jobs
     end
 
-    context 'outgoing jobs ready to start' do
-      let(:started_at) { nil }
-      it { expect(item).to have_received(:persist_and_perform_async!) }
-    end
-
-    context 'outgoing jobs havent ready to start' do
-      let(:started_at) { Time.now.to_i }
-      it { expect(item).not_to have_received(:persist_and_perform_async!) }
+    it do
+      expect(client).to have_received(:check_or_lock) do |&block|
+        expect(block).to be_kind_of Proc
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
There was a bug that related to dynamic workflow. The race condition issue happens since there are many incoming jobs that finish at the same time. It will cause duplicated outcoming jobs to be enqueued.
### Solution
Using `redis-mutex` to lock the enques_outgoing_jobs with specific job_name and workflow_id